### PR TITLE
Fix build errors

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,3 @@
-'use server'
-
 import '@/styles/globals.css'
 import { Roboto_Slab, Source_Sans_3 } from 'next/font/google'
 import Sidebar from '@/components/Sidebar'

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -4,6 +4,7 @@ import styles from "@/styles/article.module.css";
 import Icon from "./Icon";
 import clsx from "clsx";
 import { marked } from "marked";
+import { robotoSlab } from '@/styles/fonts';
 
 export default function Article ({title, tag, date, content}) {
 

--- a/src/components/Heading.js
+++ b/src/components/Heading.js
@@ -1,5 +1,6 @@
 import styles from "@/styles/heading.module.css";
 import clsx from "clsx";
+import { robotoSlab } from '@/styles/fonts';
 
 export default function Heading () {
     return(

--- a/src/styles/fonts.js
+++ b/src/styles/fonts.js
@@ -1,0 +1,4 @@
+import { Roboto_Slab, Source_Sans_3 } from 'next/font/google';
+
+export const sourceSans3 = Source_Sans_3({ subsets: ['latin'] });
+export const robotoSlab = Roboto_Slab({ subsets: ['latin'] });


### PR DESCRIPTION
Fixes build errors.

New file `@/styles/fonts` doesn't have to be in the exact directory.

Originally [a question from Reddit](https://web.archive.org/web/https://old.reddit.com/r/nextjs/comments/170mbb6/errors_trying_to_export_metadata_from_layoutjs/).

# Preview
<img width="507" alt="image" src="https://github.com/francescobarbieri/francescobarbieri.blog/assets/1967998/38f587b1-feee-4126-9729-efdc445f8d4d">
